### PR TITLE
Refactor orderBy to orderByDesc and orderByAsc

### DIFF
--- a/src/query_builder.py
+++ b/src/query_builder.py
@@ -23,6 +23,7 @@ class QueryBuilder:
         self.or_where_conditions: list[str] = []
         self.params: list[Any] = []
         self.order_by_clause = ""
+        self.order_by_parts: list[str] = []
         self.limit_count: int | None = None
         self.offset_count: int | None = None
 
@@ -34,6 +35,7 @@ class QueryBuilder:
         new_builder.or_where_conditions = self.or_where_conditions.copy()
         new_builder.params = self.params.copy()
         new_builder.order_by_clause = self.order_by_clause
+        new_builder.order_by_parts = self.order_by_parts.copy()
         new_builder.limit_count = self.limit_count
         new_builder.offset_count = self.offset_count
         return new_builder
@@ -261,7 +263,22 @@ class QueryBuilder:
     def order_by(self, clause: str) -> "QueryBuilder":
         """Add ORDER BY clause"""
         new_builder = self._clone()
+        new_builder.order_by_parts = []
         new_builder.order_by_clause = f" ORDER BY {clause}"
+        return new_builder
+
+    def order_by_asc(self, field: str) -> "QueryBuilder":
+        """Add an ORDER BY ... ASC on the given field. Can be chained to add multiple fields."""
+        new_builder = self._clone()
+        new_builder.order_by_clause = ""
+        new_builder.order_by_parts.append(f"{field}")
+        return new_builder
+
+    def order_by_desc(self, field: str) -> "QueryBuilder":
+        """Add an ORDER BY ... DESC on the given field. Can be chained to add multiple fields."""
+        new_builder = self._clone()
+        new_builder.order_by_clause = ""
+        new_builder.order_by_parts.append(f"{field} DESC")
         return new_builder
 
     def limit(self, count: int) -> "QueryBuilder":
@@ -326,7 +343,9 @@ class QueryBuilder:
             else:
                 query_parts.append(f"WHERE {' OR '.join(where_parts)}")
 
-        if self.order_by_clause:
+        if self.order_by_parts:
+            query_parts.append(f"ORDER BY {', '.join(self.order_by_parts)}")
+        elif self.order_by_clause:
             query_parts.append(self.order_by_clause.strip())
 
         if self.limit_count is not None:

--- a/src/repository.py
+++ b/src/repository.py
@@ -91,6 +91,18 @@ class Repository[T: BaseModel, S: BaseModel, U: BaseModel]:
         new_builder = current_builder.order_by(clause)
         return self._clone_with_query_builder(new_builder)
 
+    def order_by_asc(self, field: str) -> "Repository[T, S, U]":
+        """Add ORDER BY ... ASC for a field. Can be chained for multiple fields."""
+        current_builder = self._get_or_create_query_builder()
+        new_builder = current_builder.order_by_asc(field)
+        return self._clone_with_query_builder(new_builder)
+
+    def order_by_desc(self, field: str) -> "Repository[T, S, U]":
+        """Add ORDER BY ... DESC for a field. Can be chained for multiple fields."""
+        current_builder = self._get_or_create_query_builder()
+        new_builder = current_builder.order_by_desc(field)
+        return self._clone_with_query_builder(new_builder)
+
     def limit(self, count: int) -> "Repository[T, S, U]":
         """Set the LIMIT clause"""
         current_builder = self._get_or_create_query_builder()

--- a/tests/query_builder/test_basic_operations.py
+++ b/tests/query_builder/test_basic_operations.py
@@ -69,7 +69,7 @@ class TestBasicOperations:
         query1, params1 = (
             builder1.select("title")
             .where("id", str(post_id))
-            .order_by("created_at")
+            .order_by_asc("created_at")
             .build()
         )
 
@@ -78,7 +78,7 @@ class TestBasicOperations:
         query2, params2 = (
             builder2.where("id", str(post_id))
             .select("title")
-            .order_by("created_at")
+            .order_by_asc("created_at")
             .build()
         )
 
@@ -94,18 +94,18 @@ class TestBasicOperations:
         query, params = (
             builder.select("title")
             .select("content")  # This should override the previous select
-            .order_by("created_at")
-            .order_by("title DESC")  # This should override the previous order_by
+            .order_by_asc("created_at")
+            .order_by_desc("title")  # This should override the previous order_by
             .build()
         )
 
-        assert query == "SELECT content FROM posts ORDER BY title DESC"
+        assert query == "SELECT content FROM posts ORDER BY created_at, title DESC"
         assert params == []
 
     def test_empty_where_conditions(self):
         """Test that empty WHERE conditions don't break the query"""
         builder = QueryBuilder("posts")
-        query, params = builder.select("*").order_by("id").build()
+        query, params = builder.select("*").order_by_asc("id").build()
 
         assert query == "SELECT * FROM posts ORDER BY id"
         assert params == []
@@ -113,7 +113,7 @@ class TestBasicOperations:
     def test_string_representation(self):
         """Test the string representation of QueryBuilder"""
         builder = QueryBuilder("posts")
-        builder = builder.where("id", "123").order_by("title")
+        builder = builder.where("id", "123").order_by_asc("title")
 
         str_repr = str(builder)
         assert "Query: SELECT * FROM posts WHERE id = $1 ORDER BY title" in str_repr
@@ -132,7 +132,7 @@ class TestBasicOperations:
             builder.select("title, content")
             .where("published", True)
             .or_where_in("category", ["tech", "science"])
-            .order_by("created_at DESC")
+            .order_by_desc("created_at")
             .to_sql()
         )
 

--- a/tests/query_builder/test_order_by_and_complex.py
+++ b/tests/query_builder/test_order_by_and_complex.py
@@ -13,7 +13,7 @@ class TestOrderByAndComplexQueries:
     def test_order_by_clause(self):
         """Test SELECT with ORDER BY"""
         builder = QueryBuilder("posts")
-        query, params = builder.order_by("created_at DESC").build()
+        query, params = builder.order_by_desc("created_at").build()
 
         assert query == "SELECT * FROM posts ORDER BY created_at DESC"
         assert params == []
@@ -27,7 +27,7 @@ class TestOrderByAndComplexQueries:
             builder.select("title, content, created_at")
             .where("id", str(post_id))
             .where("status", status)
-            .order_by("created_at DESC")
+            .order_by_desc("created_at")
             .build()
         )
 
@@ -48,7 +48,7 @@ class TestOrderByAndComplexQueries:
             .where_in("category", ["tech", "science"])
             .or_where("featured", True)
             .where_not_in("status", ["draft", "archived"])
-            .order_by("views DESC, created_at ASC")
+            .order_by_desc("views").order_by_asc("created_at")
             .build()
         )
 
@@ -76,7 +76,7 @@ class TestOrderByAndComplexQueries:
             .where("user_id", "123")
             .where_group(status_group)
             .or_where_group(category_group)
-            .order_by("created_at DESC")
+            .order_by_desc("created_at")
             .build()
         )
 
@@ -106,7 +106,7 @@ class TestOrderByAndComplexQueries:
             .where_in("category_id", [1, 2, 3, 5])
             .where_not_in("status", ["draft", "archived"])
             .where_group(visibility_conditions)
-            .order_by("featured DESC, created_at DESC")
+            .order_by_desc("featured").order_by_desc("created_at")
             .build()
         )
 

--- a/tests/query_builder/test_pagination.py
+++ b/tests/query_builder/test_pagination.py
@@ -37,7 +37,7 @@ class TestPaginationFeatures:
         builder = QueryBuilder("posts")
         query, params = (
             builder.where("published", True)
-            .order_by("created_at DESC")
+            .order_by_desc("created_at")
             .limit(5)
             .offset(10)
             .build()
@@ -89,7 +89,7 @@ class TestPaginationFeatures:
             builder.select("id, title, content")
             .where("published", True)
             .where_in("category", ["tech", "science"])
-            .order_by("created_at DESC")
+            .order_by_desc("created_at")
             .paginate(page=2, per_page=15)
             .build()
         )

--- a/tests/test_repository_with_query_builder.py
+++ b/tests/test_repository_with_query_builder.py
@@ -193,7 +193,7 @@ class TestRepositoryWithQueryBuilder:
         await self.setup_test_data(sample_posts)
 
         # Test ORDER BY
-        ordered_posts = await repository.order_by("title ASC").get()
+        ordered_posts = await repository.order_by_asc("title").get()
         assert len(ordered_posts) == 5
         titles = [post.title for post in ordered_posts]
         assert titles == sorted(titles)
@@ -244,7 +244,7 @@ class TestRepositoryWithQueryBuilder:
         results = (
             await repository.where("published", True)
             .where_in("category", ["tech", "lifestyle"])
-            .order_by("title DESC")
+            .order_by_desc("title")
             .limit(2)
             .get()
         )


### PR DESCRIPTION
Refactor `orderBy` into explicit `orderByAsc` and `orderByDesc` methods for chainable, multi-field sorting.

The original `orderBy` method accepted a single string, which was less composable for multi-field sorting. The new `orderByAsc` and `orderByDesc` methods allow for explicit direction and can be chained to build complex order clauses, improving readability and flexibility. The original `orderBy` method is preserved for backward compatibility, with the last-called sorting method (either `orderBy` or the new `orderByAsc`/`orderByDesc` chain) determining the final SQL ORDER BY clause.

---
<a href="https://cursor.com/background-agent?bcId=bc-1faafc36-4b70-47c3-bea8-02d4a863ff92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1faafc36-4b70-47c3-bea8-02d4a863ff92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

