### PR TITLE
Improve query builder readability with explicit operators

### DIFF
--- a/src/repository.py
+++ b/src/repository.py
@@ -58,19 +58,25 @@ class Repository[T: BaseModel, S: BaseModel, U: BaseModel]:
         return self._clone_with_query_builder(new_builder)
 
     def where(
-        self, field: str, value: Any, operator: str = "="
+        self, field: str, arg2: Any, arg3: Any | None = None
     ) -> "Repository[T, S, U]":
-        """Add a WHERE condition"""
+        """Add a WHERE condition.
+
+        Supports both: where(field, value) and where(field, operator, value)
+        """
         current_builder = self._get_or_create_query_builder()
-        new_builder = current_builder.where(field, value, operator)
+        new_builder = current_builder.where(field, arg2, arg3)
         return self._clone_with_query_builder(new_builder)
 
     def or_where(
-        self, field: str, value: Any, operator: str = "="
+        self, field: str, arg2: Any, arg3: Any | None = None
     ) -> "Repository[T, S, U]":
-        """Add an OR WHERE condition"""
+        """Add an OR WHERE condition.
+
+        Supports both: or_where(field, value) and or_where(field, operator, value)
+        """
         current_builder = self._get_or_create_query_builder()
-        new_builder = current_builder.or_where(field, value, operator)
+        new_builder = current_builder.or_where(field, arg2, arg3)
         return self._clone_with_query_builder(new_builder)
 
     def where_in(self, field: str, values: list) -> "Repository[T, S, U]":


### PR DESCRIPTION
Enable `QueryBuilder` and `Repository` `where` methods to accept the operator as the second argument for better readability, while maintaining backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-41ee519f-d60d-45e1-aaeb-02c84d0e7f29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41ee519f-d60d-45e1-aaeb-02c84d0e7f29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

